### PR TITLE
feat: Create data pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1"
   },
+  "devDependencies": {
+    "prop-types": "^15.7.2"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './styles.css';
+
+export default function Pagination({ 
+  handlePrevPage, 
+  handleNextPage, 
+  prevButtonDisabled, 
+  nextButtonDisabled,
+  ...rest 
+}) {
+  return (
+    <section className="pagination" {...rest}>
+      <button 
+        type="button" 
+        onClick={handlePrevPage} 
+        disabled={prevButtonDisabled}>
+        { !prevButtonDisabled && (<a href="#top-pagination">Anterior</a>) }
+        { prevButtonDisabled && (<span>Anterior</span>) }
+      </button>
+
+      <button 
+        type="button" 
+        onClick={handleNextPage} 
+        disabled={nextButtonDisabled}>
+        { !nextButtonDisabled && (<a href="#top-pagination">Próximo</a>) }
+        { nextButtonDisabled && (<span>Próximo</span>) }
+      </button>
+    </section>
+  )
+}
+
+Pagination.propTypes = {
+  handlePrevPage: PropTypes.func.isRequired,
+  handleNextPage: PropTypes.func.isRequired,
+  prevButtonDisabled: PropTypes.bool.isRequired,
+  nextButtonDisabled: PropTypes.bool.isRequired,
+}

--- a/src/components/Pagination/styles.css
+++ b/src/components/Pagination/styles.css
@@ -1,0 +1,57 @@
+.pagination {
+  max-width: 400px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 30px 0;
+  margin: 0 auto;
+}
+
+@media screen and (max-width: 500px) {
+  .pagination {
+    flex-direction: column;
+  }
+}
+
+.pagination button {
+  width: 145px;
+  background: #338ED8;
+  border: none;
+  border-radius: 30px;
+  cursor: pointer;
+  outline: none;
+  transition: all 300ms;
+}
+
+@media screen and (max-width: 500px) {
+  .pagination button + button {
+    margin-top: 20px;
+  }
+}
+
+.pagination button:not([disabled]):hover {
+  opacity: 0.8;
+  transform: scale(0.98);
+}
+
+.pagination button[disabled] {
+  background: #ddd;
+  cursor: not-allowed;
+}
+
+.pagination button span, .pagination button a {
+  display: block;
+  color: #FFF;
+  font-size: 15px;
+  text-transform: uppercase;
+  text-decoration: none;
+}
+
+.pagination button span, .pagination button a {
+  padding: 10px;
+}
+
+.pagination button a:hover {
+  background: none;
+}

--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -62,6 +62,7 @@ export default function Home() {
         event.preventDefault()
 
         setIsRecruiter(!isRecruiter)
+        setLastFetchIndex(21);
 
         // fetch data of Jobs or Professional
         if (!isRecruiter) {
@@ -72,7 +73,7 @@ export default function Home() {
             //url form for Recruiter add Jobs
             setUrlForm('https://forms.gle/zBQ3xAzZVruyTdpN9')
         } else {
-            seturlFetchData(`${baseUrl}/17LTWWLr0rB54bQOA1Ap3zzFUPfrnCsZK2EgjgruJIwc/1/public/full`)
+            seturlFetchData(`${baseUrl}/1DIOjyvCrP8wim2oedHu3SgXoD3RAZFytSnCR0xjK7e4/1/public/full`)
             setTextContextButton('Ir para Vagas')
             setAddButtonText('Adicionar Perfil')
 


### PR DESCRIPTION
Criação da paginação de dados na tela principal.

- São exibidos 20 itens por página;
- Removido contador de total de pessoas cadastradas. 
       **Motivo:** O valor retornado na api é correspondente aos dados filtrados (20 itens), e não aos dados totais de registros;

**OBS:** Como o layout está sendo repensado, o foco maior foi na funcionalidade.

**Sugestão de melhorias:**
- Exibir uma lista de valores (5, 10, 20, 50), para que o usuário selecione a quantidade de itens que deseja exibir.
